### PR TITLE
Update minimum version of pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ test =
     pytest-cov>=2.7.1
     pytest-plus
     pytest-xdist>=1.29.0
-    pytest>=5.4.0
+    pytest>=6.1.0
 rich =
     rich >= 8.0
 


### PR DESCRIPTION
fixing the minimum version required of pytest. issue #19